### PR TITLE
Fix blank report labels by escaping Pango markup in names

### DIFF
--- a/src/window.js
+++ b/src/window.js
@@ -1602,11 +1602,7 @@ export const TimeTrackerWindow = GObject.registerClass({
             const entry = entries[index];
 
             // Escape special characters for Pango markup
-            const escapeMarkup = (str) => str
-              .replace(/&/g, '&amp;')
-              .replace(/</g, '&lt;')
-              .replace(/>/g, '&gt;')
-              .replace(/"/g, '&quot;');
+            const escapeMarkup = (str) => GLib.markup_escape_text(str || "", -1);
 
             let description = "";
             if (entry.meta != null) {
@@ -2458,7 +2454,7 @@ export const TimeTrackerWindow = GObject.registerClass({
       margin_bottom: 3,
     });
     const label = new Gtk.Label();
-    label.set_markup("<b>" + title + ":</b>");
+    label.set_markup("<b>" + GLib.markup_escape_text(title || "", -1) + ":</b>");
     const button = new Gtk.Button({
       label: this.secondstoOutput(filter[0].duration),
       hexpand: true,
@@ -5593,11 +5589,7 @@ async missingentriesdialog(missingentries) {
         const row = new Adw.ActionRow();
 
         // Escape markup in project name
-        const escapeMarkup = (str) => str
-          .replace(/&/g, '&amp;')
-          .replace(/</g, '&lt;')
-          .replace(/>/g, '&gt;')
-          .replace(/"/g, '&quot;');
+        const escapeMarkup = (str) => GLib.markup_escape_text(str || "", -1);
 
         row.title = escapeMarkup(entry.project || "(no project)");
 


### PR DESCRIPTION
Using [`GLib.markup_escape_text`](https://docs.gtk.org/glib/func.markup_escape_text.html), I also removed two little duplicated helpers while I was at it. I had a project with "&" in the name and I was seeing:

<img width="1842" height="258" alt="image" src="https://github.com/user-attachments/assets/a45af94c-df46-441f-8ad9-628c0bdccd53" />

If you could please take a look @elvishcraftsman when you have a chance, TiA!